### PR TITLE
Fix typo in rec option description

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -38,7 +38,7 @@ export default {
                 },
                 {
                     label: 'rec',
-                    description: 'Get recommendationns from AI on what to do',
+                    description: 'Get recommendations from AI on what to do',
                     value: 'rec'
                 },
             ]);


### PR DESCRIPTION
## Summary
- fix a misspelling in the `rec` option description

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840f74703c88325aec1f8a6a2c02b0a